### PR TITLE
Fix lines being truncated + raw mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/korchasa/sternom/pkg"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
+
+	"github.com/korchasa/sternom/pkg"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -22,6 +23,7 @@ var (
 		FilterStr:  nil,
 		ExcludeStr: nil,
 		Color:      "auto",
+		Raw:        false,
 	}
 )
 
@@ -44,6 +46,7 @@ func main() {
 	opts.ExcludeStr = cmd.Flags().StringSliceP("exclude", "e", nil, "Exclude log records by pattern. Multiple filters: `-e a -e b` or `-e a,b`")
 	cmd.Flags().StringVar(&opts.Color, "color", opts.Color, "Color output. Can be 'always', 'never', or 'auto'")
 	cmd.Flags().BoolVarP(&opts.Version, "version", "v", opts.Version, "Print the version and exit")
+	cmd.Flags().BoolVar(&opts.Raw, "raw", opts.Raw, "Print the raw output")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if opts.Version {
@@ -53,7 +56,7 @@ func main() {
 
 		config, err := pkg.ParseCLIArguments(args[0], opts)
 		if err != nil {
-			log.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(2)
 		}
 
@@ -62,7 +65,7 @@ func main() {
 
 		err = pkg.Run(ctx, config)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 

--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -1,9 +1,10 @@
 package pkg
 
 import (
+	"os"
+
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
-	"os"
 )
 
 type Options struct {
@@ -18,6 +19,7 @@ type Options struct {
 	ExcludeStr *[]string
 	Color      string
 	Version    bool
+	Raw        bool
 }
 
 func ParseCLIArguments(prefix string, opts *Options) (*Config, error) {
@@ -56,5 +58,6 @@ func ParseCLIArguments(prefix string, opts *Options) (*Config, error) {
 		FilterStr:         opts.FilterStr,
 		ExcludeStr:        opts.ExcludeStr,
 		TailBytes:         opts.TailBytes,
+		Raw:               opts.Raw,
 	}, nil
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	FilterStr         *[]string
 	ExcludeStr        *[]string
 	TailBytes         int64
+	Raw               bool
 }

--- a/pkg/find_subscriptions.go
+++ b/pkg/find_subscriptions.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
-	"github.com/hashicorp/nomad/api"
-	"log"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/nomad/api"
 )
 
 func SubscriptionFinder(client *api.Client, subsCh chan<- Subscription, prefix string, task string) {
@@ -13,10 +14,10 @@ func SubscriptionFinder(client *api.Client, subsCh chan<- Subscription, prefix s
 	for {
 		newSubs, err := findSubscriptions(client, prefix, task)
 		if err != nil {
-			log.Fatalf("Can't find subscriptions: %s", err)
+			fmt.Fprintf(os.Stderr, "Can't find subscriptions: %s\n", err)
 		}
 		if len(newSubs) == 0 {
-			log.Printf("No jobs or allocations found by prefix `%s`", prefix)
+			fmt.Fprintf(os.Stderr, "No jobs or allocations found by prefix `%s`\n", prefix)
 		}
 		for _, ns := range newSubs {
 			found := false

--- a/pkg/log_reader.go
+++ b/pkg/log_reader.go
@@ -2,7 +2,9 @@ package pkg
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/hashicorp/nomad/api"
@@ -23,7 +25,10 @@ func LogReader(prefix string, in <-chan *api.StreamFrame, out chan<- string) {
 				continue
 			}
 
-			pw.Write(data.Data)
+			if _, err := pw.Write(data.Data); err != nil {
+				fmt.Fprintf(os.Stderr, "error writing data to pipe, err=%v\n", err)
+				return
+			}
 		}
 	}()
 

--- a/pkg/log_reader.go
+++ b/pkg/log_reader.go
@@ -1,19 +1,41 @@
 package pkg
 
 import (
+	"bufio"
+	"io"
+	"sync"
+
 	"github.com/hashicorp/nomad/api"
-	"strings"
 )
 
 func LogReader(prefix string, in <-chan *api.StreamFrame, out chan<- string) {
-	for data := range in {
-		if data == nil {
-			continue
-		}
-		for _, s := range strings.Split(string(data.Data), "\n") {
-			if len(s) > 0 {
-				out <- prefix + s
+	var wg sync.WaitGroup
+
+	pr, pw := io.Pipe()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer pw.Close()
+
+		for data := range in {
+			if data == nil {
+				continue
 			}
+
+			pw.Write(data.Data)
 		}
-	}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(pr)
+
+		for scanner.Scan() {
+			out <- prefix + scanner.Text()
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/log_records_printer.go
+++ b/pkg/log_records_printer.go
@@ -2,8 +2,9 @@ package pkg
 
 import (
 	"fmt"
-	"github.com/fatih/color"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
 func LogRecordsPrinter(outputCh <-chan string, filterStr []string, excludeStr []string) {

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -2,16 +2,34 @@ package pkg
 
 import (
 	"context"
-	"github.com/hashicorp/nomad/api"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
+
+	"github.com/hashicorp/nomad/api"
 )
 
 func Run(_ context.Context, conf *Config) error {
-	client, err := api.NewClient(&api.Config{Address: conf.NomadAddress})
+	var nomadSkipVerify bool
+	if v := os.Getenv("NOMAD_SKIP_VERIFY"); v != "" {
+		var err error
+		nomadSkipVerify, err = strconv.ParseBool(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	client, err := api.NewClient(&api.Config{
+		Address:  conf.NomadAddress,
+		SecretID: os.Getenv("NOMAD_TOKEN"),
+		TLSConfig: &api.TLSConfig{
+			Insecure: nomadSkipVerify,
+		},
+	})
 	if err != nil {
 		log.Fatalf("Can't init client: %s", err)
 	}
@@ -20,7 +38,7 @@ func Run(_ context.Context, conf *Config) error {
 	signal.Notify(cancelCh, os.Interrupt, syscall.SIGINT)
 	go func() {
 		<-cancelCh
-		log.Println("\r- Ctrl+C pressed in Terminal")
+		fmt.Fprintf(os.Stderr, "\r- Ctrl+C pressed in Terminal\n")
 		os.Exit(0)
 	}()
 


### PR DESCRIPTION
This PR fixes lines being truncated (this breaks `jq` when piped after)
It also prints information to stderr, uses insecure tls when the env var `NOMAD_SKIP_VERIFY` is set to true and adds a raw mode (useful to use `jq` or some other processing tool that needs the raw output)
